### PR TITLE
Overriding justify-content property

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -43,7 +43,6 @@
 .nav-menu {
   display: flex;
   align-items: center;
-  justify-content: center;
   list-style: none;
   text-align: center;
   justify-content: end;


### PR DESCRIPTION
The css file was overriding the justify-content property which is useless code in the .nav-menu class.